### PR TITLE
Also add convenience property for checking whether it is successful

### DIFF
--- a/MailBounceDetector/BounceDetectResult.cs
+++ b/MailBounceDetector/BounceDetectResult.cs
@@ -192,6 +192,7 @@ namespace MailBounceDetector
         public bool IsBounce => DeliveryStatus != null;
         public bool IsHard => IsBounce && PrimaryStatus != null && PrimaryStatus.Code > 4;
         public bool IsSoft => IsBounce && PrimaryStatus != null && PrimaryStatus.Code <= 4;
+        public bool IsSuccess => IsBounce && PrimaryStatus == 4;
         public BounceStatus PrimaryStatus { get; }
         public BounceStatus SecundaryStatus { get; }
         public BounceStatus CombinedStatus { get; }


### PR DESCRIPTION
It may be useful to have that, because otherwise `IsSoft`

Maybe also make `IsSoft` exclusive, as a successful status notification obviously is not a "soft" (failure) nor "hard" (failure), but no failure at all.