### PR TITLE
Upgrade to .NET 8 and update all dependencies

### DIFF
--- a/MailBounceDetector.Tests/MailBounceDetector.Tests.csproj
+++ b/MailBounceDetector.Tests/MailBounceDetector.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/MailBounceDetector.Tests/MailBounceDetector.Tests.csproj
+++ b/MailBounceDetector.Tests/MailBounceDetector.Tests.csproj
@@ -20,14 +20,14 @@
     <EmbeddedResource Include="Fixtures\non_bounce_postfix_hello_world.eml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="JunitXml.TestLogger" Version="4.0.254" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/MailBounceDetector/MailBounceDetector.csproj
+++ b/MailBounceDetector/MailBounceDetector.csproj
@@ -12,6 +12,6 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MimeKit" Version="3.3.0" />
+    <PackageReference Include="MimeKit" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/MailBounceDetector/MailBounceDetector.csproj
+++ b/MailBounceDetector/MailBounceDetector.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Detects whether a MailKit email Message is a bounce message</Description>
     <Version>1.0.4</Version>
     <Company>ruilopes.com</Company>


### PR DESCRIPTION
I've run the tests locally, and everything works, so I guess this is fine to publish. 🙂 

Used the [Visual Studio upgrade assistant](https://dotnet.microsoft.com/en-us/platform/upgrade-assistant) in case it should adjust some code, but it did not do anything, apparently.

In case you don't want some things, I've did it in different commits, so you can revert things. 

Fixes https://github.com/rgl/MailBounceDetector/issues/12
Supersedes https://github.com/rgl/MailBounceDetector/pull/14
Supersedes https://github.com/rgl/MailBounceDetector/pull/3